### PR TITLE
feat: add standalone scenario examples

### DIFF
--- a/standalone/config-standalone.yaml
+++ b/standalone/config-standalone.yaml
@@ -1,0 +1,117 @@
+#
+# Krkn Standalone Configuration
+#
+# Purpose:
+#   General-purpose krkn configuration for standalone (non-Kubernetes) mode.
+#   Runs chaos scenarios against bare-metal hosts, VMs, or any SSH-accessible
+#   infrastructure without requiring a Kubernetes or OpenShift cluster.
+#
+# How to use:
+#   1. Edit the chaos_scenarios section below to reference your scenario files
+#   2. Uncomment the scenario types you want to run
+#   3. Run: python run_kraken.py --config config-standalone.yaml
+#
+# Key differences from Kubernetes mode:
+#   - execution_mode is set to "standalone"
+#   - kubeconfig_path is left empty (no cluster needed)
+#   - Cerberus health monitoring is disabled
+#   - Prometheus/Elasticsearch monitoring is optional
+#   - Scenarios use targets + SSH instead of label_selector + cloud_type
+#
+# NOTE: Scenario paths below (scenarios/standalone/...) are relative to the krkn
+# repository root. Copy the scenario YAMLs into krkn's scenarios/standalone/
+# directory, or adjust these paths to match your directory layout.
+
+kraken:
+    execution_mode: standalone             # Run without Kubernetes cluster
+    kubeconfig_path:                       # Leave empty for standalone mode
+    exit_on_failure: False                 # Continue running after a scenario fails
+    auto_rollback: True                    # Automatically undo chaos after duration
+    rollback_versions_directory:
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        # Uncomment and edit paths to the scenarios you want to run.
+        # Each scenario file contains SSH targets and credentials.
+        #
+        # Node scenarios (reboot, crash):
+        - node_scenarios:
+            - scenarios/standalone/ssh-node-reboot.yml
+        #    - scenarios/standalone/ssh-node-crash.yml
+        #
+        # Resource hog scenarios (CPU, memory, IO stress):
+        - hog_scenarios:
+            - scenarios/standalone/cpu-hog-standalone.yml
+        #    - scenarios/standalone/memory-hog-standalone.yml
+        #    - scenarios/standalone/io-hog-standalone.yml
+        #
+        # Network chaos scenarios (latency, partition):
+        - network_chaos_scenarios:
+            - scenarios/standalone/network-latency-standalone.yml
+        #    - scenarios/standalone/network-partition-standalone.yml
+        #
+        # Time chaos scenarios (clock skew):
+        - time_scenarios:
+            - scenarios/standalone/time-skew-standalone.yml
+        #
+        # Disk fill scenarios:
+        #- standalone_disk_fill_scenarios:
+        #    - scenarios/standalone/disk-fill-standalone.yml
+        #
+        # File permission chaos:
+        #- standalone_file_scenarios:
+        #    - scenarios/standalone/file-chmod-standalone.yml
+
+tunings:
+    wait_duration: 10                      # Seconds to wait between scenarios
+    iterations: 1                          # Number of times to run all scenarios
+    daemon_mode: False                     # Run once and exit (True = loop forever)
+
+performance_monitoring:
+    prometheus_url:                        # Optional: Prometheus endpoint URL
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False                # Disabled in standalone mode
+    cerberus_url:
+
+elastic:
+    enable_elastic: False                  # Set to True to send telemetry
+    elastic_url:
+    elastic_port: 32766
+    verify_certs: False
+    username:
+    password:
+    metrics_index: krkn-metrics
+    alerts_index: krkn-alerts
+    telemetry_index: krkn-telemetry
+
+telemetry:
+    enabled: False
+    api_url:
+    username:
+    password:
+    prometheus_backup: False
+    full_prometheus_backup: False
+    events_backup: False
+    logs_backup: False
+    backup_threads: 5
+    archive_path:
+    max_retries: 0
+    run_tag:
+    telemetry_group:
+
+resiliency:
+    resiliency_run_mode: disabled
+
+health_checks:
+
+kubevirt_checks:

--- a/standalone/config-vmware-validation.yaml
+++ b/standalone/config-vmware-validation.yaml
@@ -1,0 +1,109 @@
+#
+# VMware Migration Validation Configuration
+#
+# Purpose:
+#   Validates that VMs migrated from VMware to OpenShift Virtualization (CNV)
+#   or to RHEL+KVM survive common failure scenarios. Run this after completing
+#   a VMware-to-OpenShift migration to gain confidence in the new environment.
+#
+# What it validates:
+#   - Migrated VMs restart cleanly after host reboot (CNV-83327)
+#   - Network performance is acceptable post-migration (CNV-90425)
+#   - Storage IO bursts do not crash VMIs (CNV-79002)
+#   - Host CPU stress does not break virt-handler (CNV-89810)
+#
+# How to use:
+#   1. Edit each scenario YAML referenced below:
+#      - Replace <WORKER_NODE_*> with your actual node IPs
+#      - Replace <MIGRATED_VM_NAME> and <NAMESPACE> with VM details
+#   2. Run: python run_kraken.py --config config-vmware-validation.yaml
+#   3. Review results: all 4 scenarios should pass for migration sign-off
+#
+# Scenario execution order:
+#   1. Node reboot     - validates VM survival after host restart
+#   2. Network latency - validates connectivity under degraded network
+#   3. Storage IO      - validates disk resilience under IO burst
+#   4. CPU stress      - validates host stability under CPU pressure
+#
+# NOTE: Scenario paths below (scenarios/standalone/...) are relative to the krkn
+# repository root. Copy the scenario YAMLs into krkn's scenarios/standalone/
+# directory, or adjust these paths to match your directory layout.
+
+kraken:
+    execution_mode: standalone             # Run without requiring the original VMware env
+    kubeconfig_path:                       # Leave empty for standalone validation
+    exit_on_failure: False                 # Run all scenarios even if one fails
+    auto_rollback: True                    # Automatically undo chaos after each scenario
+    rollback_versions_directory:
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        # Step 1: Reboot worker nodes to verify VMs survive restart
+        - node_scenarios:
+            - scenarios/standalone/ssh-node-reboot.yml
+
+        # Step 2: Network latency to verify connectivity resilience
+        - network_chaos_scenarios:
+            - scenarios/standalone/network-latency-standalone.yml
+
+        # Step 3: Storage IO stress to verify disk resilience
+        - vm_storage_chaos_scenarios:
+            - scenarios/standalone/vm-storage-nfs-failover.yml
+
+        # Step 4: CPU stress to verify host stability
+        - hog_scenarios:
+            - scenarios/standalone/cpu-hog-standalone.yml
+
+tunings:
+    wait_duration: 30                      # Longer wait between scenarios for VM recovery
+    iterations: 1                          # Run validation suite once
+    daemon_mode: False                     # Run once and exit
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+    elastic_url:
+    elastic_port: 32766
+    verify_certs: False
+    username:
+    password:
+    metrics_index: krkn-metrics
+    alerts_index: krkn-alerts
+    telemetry_index: krkn-telemetry
+
+telemetry:
+    enabled: False
+    api_url:
+    username:
+    password:
+    prometheus_backup: False
+    full_prometheus_backup: False
+    events_backup: False
+    logs_backup: False
+    backup_threads: 5
+    archive_path:
+    max_retries: 0
+    run_tag:
+    telemetry_group:
+
+resiliency:
+    resiliency_run_mode: disabled
+
+health_checks:
+
+kubevirt_checks:

--- a/standalone/cpu-hog-standalone.yml
+++ b/standalone/cpu-hog-standalone.yml
@@ -1,0 +1,36 @@
+#
+# Standalone CPU Stress Test
+#
+# Purpose:
+#   Consumes CPU on bare-metal or VM hosts via SSH using stress-ng.
+#   Validates that applications degrade gracefully under CPU contention
+#   rather than crashing or producing corrupt output.
+#
+# What it catches:
+#   - Services that crash when starved of CPU (missing resource limits)
+#   - Liveness probes that timeout under CPU pressure (CNV-89810)
+#   - Scheduler starvation causing missed cron jobs or heartbeats
+#   - OOM kills triggered by CPU-bound processes allocating memory
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts
+#   - stress-ng installed on targets (or will be installed by krkn)
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Adjust cpu-load-percentage and duration for your test
+#   3. Reference this file in config/config.yaml under chaos_scenarios:
+#        - hog_scenarios:
+#            - ../scenarios-hub/standalone/cpu-hog-standalone.yml
+#
+
+hog-type: cpu
+targets:
+  - <TARGET_HOST_1>                        # IP or hostname of first target
+  - <TARGET_HOST_2>                        # IP or hostname of second target
+ssh_user: root                             # SSH username
+ssh_private_key: ~/.ssh/id_rsa             # Path to SSH private key
+node-selector: ""                          # Not used in standalone mode
+duration: 60                               # Duration in seconds to run stress
+workers: 0                                 # Number of CPU workers (0 = all cores)
+cpu-load-percentage: 90                    # Target CPU load percentage

--- a/standalone/disk-fill-standalone.yml
+++ b/standalone/disk-fill-standalone.yml
@@ -1,0 +1,36 @@
+#
+# Standalone Disk Fill via SSH
+#
+# Purpose:
+#   Fills disk space on bare-metal or VM hosts via SSH using fallocate.
+#   Validates that applications handle disk exhaustion gracefully with
+#   proper error messages rather than silent data loss or corruption.
+#
+# What it catches:
+#   - Applications that crash instead of returning disk-full errors
+#   - Log files that silently stop writing when disk is full
+#   - Databases that corrupt WAL segments on disk exhaustion
+#   - Container runtimes that fail to pull images or create layers
+#   - /tmp exhaustion breaking application temp file operations
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts
+#   - fallocate available on targets (part of util-linux)
+#   - Choose fill_path and fill_percentage carefully to avoid host lockout
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Set fill_path to the filesystem you want to fill (e.g. /tmp, /var)
+#   3. Set fill_percentage to a safe value (start low, e.g. 80%)
+#   4. Reference this file in config/config.yaml under chaos_scenarios:
+#        - standalone_disk_fill_scenarios:
+#            - ../scenarios-hub/standalone/disk-fill-standalone.yml
+#
+
+targets:
+  - <TARGET_HOST_1>                        # IP or hostname of target
+ssh_user: root                             # SSH username
+ssh_private_key: ~/.ssh/id_rsa             # Path to SSH private key
+fill_path: /tmp                            # Filesystem path to fill
+fill_percentage: 90                        # Target percentage to fill (0-99)
+duration: 120                              # Duration in seconds before cleanup

--- a/standalone/file-chmod-standalone.yml
+++ b/standalone/file-chmod-standalone.yml
@@ -1,0 +1,37 @@
+#
+# Standalone File Permission Chaos via SSH
+#
+# Purpose:
+#   Changes file permissions on bare-metal or VM hosts via SSH using chmod.
+#   Simulates accidental permission changes that break application access
+#   to critical configuration files, sockets, or data directories.
+#
+# What it catches:
+#   - Services that crash when config files become unreadable
+#   - Socket permission errors breaking inter-process communication
+#   - Applications that fail silently instead of reporting permission denied
+#   - Security tools that do not alert on critical file permission changes
+#   - Services that cannot restart because pid/lock files are inaccessible
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts
+#   - Choose file_path carefully (do not target /etc/shadow or SSH keys)
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Set file_path to the config or data file you want to test
+#   3. Set permissions to the restrictive mode (e.g. "000" for no access)
+#   4. Original permissions are restored after duration expires
+#   5. Reference this file in config/config.yaml under chaos_scenarios:
+#        - standalone_file_scenarios:
+#            - ../scenarios-hub/standalone/file-chmod-standalone.yml
+#
+
+targets:
+  - <TARGET_HOST_1>                        # IP or hostname of target
+ssh_user: root                             # SSH username
+ssh_private_key: ~/.ssh/id_rsa             # Path to SSH private key
+action: chmod                              # Permission change action
+file_path: /etc/nginx/nginx.conf           # Path to file to change permissions on
+permissions: "000"                         # New permissions (restored after duration)
+duration: 60                               # Duration in seconds before restoring

--- a/standalone/io-hog-standalone.yml
+++ b/standalone/io-hog-standalone.yml
@@ -1,0 +1,37 @@
+#
+# Standalone IO Stress Test
+#
+# Purpose:
+#   Generates IO load on bare-metal or VM hosts via SSH using stress-ng.
+#   Validates that storage subsystems handle sustained IO pressure without
+#   data loss or service degradation.
+#
+# What it catches:
+#   - Disk IO saturation causing application write failures
+#   - Log rotation failures under IO contention
+#   - Database transaction timeouts from slow fsync
+#   - CNV-79002: IO burst crashing Virtual Machine Instances
+#   - NFS mounts going stale under IO pressure
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts
+#   - stress-ng installed on targets (or will be installed by krkn)
+#   - Sufficient disk space on target path for IO operations
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Adjust io-bytes and duration for your environment
+#   3. Reference this file in config/config.yaml under chaos_scenarios:
+#        - hog_scenarios:
+#            - ../scenarios-hub/standalone/io-hog-standalone.yml
+#
+
+hog-type: io
+targets:
+  - <TARGET_HOST_1>                        # IP or hostname of target
+ssh_user: root                             # SSH username
+ssh_private_key: ~/.ssh/id_rsa             # Path to SSH private key
+node-selector: ""                          # Not used in standalone mode
+duration: 60                               # Duration in seconds to run IO stress
+workers: 4                                 # Number of IO workers
+io-bytes: 1G                              # Amount of data each worker writes

--- a/standalone/memory-hog-standalone.yml
+++ b/standalone/memory-hog-standalone.yml
@@ -1,0 +1,35 @@
+#
+# Standalone Memory Stress Test
+#
+# Purpose:
+#   Allocates memory on bare-metal or VM hosts via SSH using stress-ng.
+#   Validates that the system handles memory pressure without critical
+#   service crashes or unrecoverable OOM conditions.
+#
+# What it catches:
+#   - OOM killer targeting the wrong process (critical services killed)
+#   - Memory leaks exposed under pressure (services that never release)
+#   - Swap thrashing causing application timeouts
+#   - Database buffer pools evicted causing performance collapse
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts
+#   - stress-ng installed on targets (or will be installed by krkn)
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Adjust memory-vm-bytes to a safe value for your hosts
+#   3. Reference this file in config/config.yaml under chaos_scenarios:
+#        - hog_scenarios:
+#            - ../scenarios-hub/standalone/memory-hog-standalone.yml
+#
+
+hog-type: memory
+targets:
+  - <TARGET_HOST_1>                        # IP or hostname of target
+ssh_user: root                             # SSH username
+ssh_private_key: ~/.ssh/id_rsa             # Path to SSH private key
+node-selector: ""                          # Not used in standalone mode
+duration: 60                               # Duration in seconds to hold memory
+workers: 1                                 # Number of memory workers
+memory-vm-bytes: 256M                      # Amount of memory each worker allocates

--- a/standalone/network-latency-standalone.yml
+++ b/standalone/network-latency-standalone.yml
@@ -1,0 +1,40 @@
+#
+# Standalone Network Latency Injection
+#
+# Purpose:
+#   Adds network latency to host interfaces via SSH using tc netem.
+#   Simulates degraded WAN links, cross-datacenter latency, or congested
+#   network segments without touching Kubernetes networking.
+#
+# What it catches:
+#   - Application timeouts from increased round-trip time
+#   - Database replication lag causing stale reads
+#   - Health check failures from slow responses
+#   - CNV-90425: VM performance degradation after migration
+#   - Load balancer evictions from backend response delays
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts
+#   - tc (iproute2) installed on targets
+#   - Network interface names known (use `ip link show` to find them)
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Set interfaces to the correct network interfaces on target
+#   3. Adjust latency and duration for your test scenario
+#   4. Reference this file in config/config.yaml under chaos_scenarios:
+#        - network_chaos_scenarios:
+#            - ../scenarios-hub/standalone/network-latency-standalone.yml
+#
+
+network_chaos:
+  targets:
+    - <TARGET_HOST_1>                      # IP or hostname of target
+  ssh_user: root                           # SSH username
+  ssh_private_key: ~/.ssh/id_rsa           # Path to SSH private key
+  duration: 300                            # Duration in seconds to hold the fault
+  interfaces:                              # Network interfaces to inject latency on
+    - eth0                                 # Change to match your host (e.g. ens192, bond0)
+  execution: serial                        # serial or parallel interface injection
+  egress:
+    latency: 100ms                         # Latency to add to outgoing packets

--- a/standalone/network-partition-standalone.yml
+++ b/standalone/network-partition-standalone.yml
@@ -1,0 +1,41 @@
+#
+# Standalone Network Partition via SSH
+#
+# Purpose:
+#   Creates a network partition using iptables rules via SSH. Simulates a
+#   split-brain condition where a host is completely cut off from specific
+#   peers or subnets. Tests that distributed systems handle partitions
+#   without data corruption or split-brain conflicts.
+#
+# What it catches:
+#   - Split-brain in clustered databases (etcd, Galera, Patroni)
+#   - Consensus protocol failures when quorum is lost
+#   - Application writes accepted on both sides of a partition
+#   - Monitoring blind spots where alerts do not fire during partition
+#   - Recovery race conditions when partition heals
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts
+#   - iptables installed on targets
+#   - Understand which traffic you are blocking before running
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Set interfaces to the correct network interfaces on target
+#   3. Packet loss of 100% simulates a full partition
+#   4. Reference this file in config/config.yaml under chaos_scenarios:
+#        - network_chaos_scenarios:
+#            - ../scenarios-hub/standalone/network-partition-standalone.yml
+#
+
+network_chaos:
+  targets:
+    - <TARGET_HOST_1>                      # IP or hostname of target to partition
+  ssh_user: root                           # SSH username
+  ssh_private_key: ~/.ssh/id_rsa           # Path to SSH private key
+  duration: 120                            # Duration in seconds to hold the partition
+  interfaces:                              # Network interfaces to apply partition on
+    - eth0                                 # Change to match your host (e.g. ens192, bond0)
+  execution: serial                        # serial or parallel interface injection
+  egress:
+    loss: 100%                             # 100% packet loss = full network partition

--- a/standalone/ssh-node-crash.yml
+++ b/standalone/ssh-node-crash.yml
@@ -1,0 +1,39 @@
+#
+# Standalone Node Kernel Crash via SSH
+#
+# Purpose:
+#   Triggers a kernel panic on target hosts via sysrq to simulate a hard
+#   crash. Tests whether the host recovers cleanly from an unplanned
+#   kernel failure, including filesystem journal replay and service restart.
+#
+# What it catches:
+#   - Filesystems that fail to remount after journal replay
+#   - Services that hang during crash recovery (e.g. database lock files)
+#   - Network bonds or LACP that do not renegotiate after crash
+#   - Kernel modules that fail to reload on boot
+#
+# Prerequisites:
+#   - SSH key-based root access to target hosts
+#   - sysrq must be enabled on target (sysctl kernel.sysrq=1)
+#   - Target hosts should have a watchdog or IPMI for guaranteed reboot
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Reference this file in config/config.yaml under chaos_scenarios:
+#        - node_scenarios:
+#            - ../scenarios-hub/standalone/ssh-node-crash.yml
+#
+
+node_scenarios:
+  - actions:
+      - node_crash_scenario
+    cloud_type: ssh
+    targets:
+      - <TARGET_HOST_1>                    # IP or hostname of target
+    ssh_user: root                         # Must be root for sysrq trigger
+    ssh_private_key: ~/.ssh/id_rsa         # Path to SSH private key
+    ssh_port: 22                           # SSH port (default 22)
+    runs: 1                                # Number of crash cycles
+    timeout: 600                           # Seconds to wait for host recovery
+    kube_check: false                      # No Kubernetes API checks in standalone mode
+    soft_reboot: false                     # Hard crash (kernel panic), not graceful reboot

--- a/standalone/ssh-node-reboot.yml
+++ b/standalone/ssh-node-reboot.yml
@@ -1,0 +1,40 @@
+#
+# Standalone Node Reboot via SSH
+#
+# Purpose:
+#   Reboots bare-metal or VM hosts over SSH without requiring a Kubernetes
+#   control plane. Validates that services restart cleanly after an
+#   unexpected reboot and that no data corruption occurs on disk.
+#
+# What it catches:
+#   - Services that fail to start on boot (missing systemd enable)
+#   - Filesystem corruption from unclean shutdown
+#   - Network interfaces that do not come back with correct IP/routes
+#   - CNV-83327: Windows VM disks going offline after host reboot
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts (no password prompts)
+#   - Target hosts must be reachable from the machine running krkn
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Set ssh_user and ssh_private_key to match your environment
+#   3. Reference this file in config/config.yaml under chaos_scenarios:
+#        - node_scenarios:
+#            - ../scenarios-hub/standalone/ssh-node-reboot.yml
+#
+
+node_scenarios:
+  - actions:
+      - node_reboot_scenario
+    cloud_type: ssh
+    targets:
+      - <TARGET_HOST_1>                    # IP or hostname of first target
+      - <TARGET_HOST_2>                    # IP or hostname of second target
+    ssh_user: root                         # SSH username with reboot privileges
+    ssh_private_key: ~/.ssh/id_rsa         # Path to SSH private key
+    ssh_port: 22                           # SSH port (default 22)
+    runs: 1                                # Number of times to run the reboot
+    timeout: 360                           # Seconds to wait for host to come back
+    kube_check: false                      # No Kubernetes API checks in standalone mode
+    soft_reboot: true                      # Use graceful reboot (false = hard reset)

--- a/standalone/time-skew-standalone.yml
+++ b/standalone/time-skew-standalone.yml
@@ -1,0 +1,37 @@
+#
+# Standalone Time Skew via SSH
+#
+# Purpose:
+#   Skews the system clock on bare-metal or VM hosts via SSH using
+#   timedatectl. Validates that applications handle clock drift without
+#   producing incorrect results, expired tokens, or broken certificates.
+#
+# What it catches:
+#   - TLS certificate validation failures from clock skew
+#   - Token expiry and authentication failures (JWT, OAuth, Kerberos)
+#   - Cron jobs firing at wrong times or being skipped entirely
+#   - Log timestamp disorder breaking log aggregation pipelines
+#   - Database transaction ordering issues from skewed clocks
+#   - Distributed consensus failures (Raft, Paxos) from time disagreement
+#
+# Prerequisites:
+#   - SSH key-based access to target hosts
+#   - timedatectl available on targets (systemd-based systems)
+#   - NTP will be temporarily disabled during the test
+#
+# Usage:
+#   1. Replace <TARGET_HOST_*> with real IPs or hostnames
+#   2. Adjust duration for how long the clock should stay skewed
+#   3. Reference this file in config/config.yaml under chaos_scenarios:
+#        - time_scenarios:
+#            - ../scenarios-hub/standalone/time-skew-standalone.yml
+#
+
+time_scenarios:
+  - action: skew_time                      # skew_time or skew_date
+    targets:
+      - <TARGET_HOST_1>                    # IP or hostname of target
+    ssh_user: root                         # SSH username
+    ssh_private_key: ~/.ssh/id_rsa         # Path to SSH private key
+    duration: 300                          # Duration in seconds to hold the skew
+    disable_ntp: true                      # Disable NTP during test to prevent correction

--- a/standalone/vm-migration-network-disruption.yml
+++ b/standalone/vm-migration-network-disruption.yml
@@ -1,0 +1,42 @@
+#
+# VM Live Migration Under Network Disruption
+#
+# Purpose:
+#   Triggers a VM live migration and simultaneously injects network latency
+#   on the migration path. Validates that the migration either completes
+#   successfully or rolls back cleanly without leaving duplicate pods or
+#   corrupted VM state.
+#
+# What it catches:
+#   - CNV-89391: Dual virt-launcher pods after failed migration (data corruption)
+#   - Migration timeouts that leave VM in an inconsistent state
+#   - Network faults causing migration data stream corruption
+#   - CNV-90425: Performance degradation after VMware-to-CNV migration
+#   - Split-brain where both source and target claim VM ownership
+#
+# Prerequisites:
+#   - SSH key-based access to the VM host nodes
+#   - A running VM that supports live migration
+#   - Network interface name for the migration network (e.g. br-ex)
+#
+# Usage:
+#   1. Replace <MIGRATED_VM_NAME> and <NAMESPACE> with your VM details
+#   2. Set fault_params to match your migration network interface
+#   3. Reference this file in config/config.yaml under chaos_scenarios:
+#        - vm_migration_chaos_scenarios:
+#            - ../scenarios-hub/standalone/vm-migration-network-disruption.yml
+#
+
+vm_migration_chaos:
+  vm_name: <MIGRATED_VM_NAME>              # Name of the VM to migrate
+  vm_namespace: <NAMESPACE>                # Namespace where the VM runs
+  migration_action: trigger_and_disrupt    # Start migration then inject fault
+  fault_type: network_latency              # Type of fault to inject during migration
+  fault_params:
+    latency: 200ms                         # Latency to add to migration network
+    interface: br-ex                       # Network interface used for migration
+    duration: 30                           # Seconds to hold the fault active
+  ssh_user: core                           # SSH username on host nodes
+  ssh_private_key: ~/.ssh/id_rsa           # Path to SSH private key
+  verify_no_dual_pods: true                # Verify no duplicate virt-launcher pods
+  timeout: 600                             # Seconds to wait for migration completion

--- a/standalone/vm-storage-nfs-failover.yml
+++ b/standalone/vm-storage-nfs-failover.yml
@@ -1,0 +1,41 @@
+#
+# VM Storage NFS Failover Chaos
+#
+# Purpose:
+#   Kills the NFS server process on a storage node to simulate an NFS
+#   failover event. Validates that VMs or applications using NFS-backed
+#   storage survive the outage and resume IO without data loss once the
+#   NFS service recovers.
+#
+# What it catches:
+#   - VMs that crash when NFS mount goes stale (EIO errors)
+#   - Applications that hang indefinitely on NFS operations (soft vs hard mount)
+#   - Data corruption from interrupted NFS writes during failover
+#   - CNV-79002: IO burst crashes VMI when storage is disrupted
+#   - Backup jobs that fail silently when NFS is unavailable
+#
+# Prerequisites:
+#   - SSH key-based access to the NFS server host
+#   - Know the NFS service name (nfs-server, nfs-kernel-server, etc.)
+#   - Clients should use hard mounts for production (this test validates that)
+#
+# Usage:
+#   1. Replace <NFS_SERVER_HOST> with the NFS server IP or hostname
+#   2. Adjust duration and recovery_timeout for your environment
+#   3. Reference this file in config/config.yaml under chaos_scenarios:
+#        - vm_storage_chaos_scenarios:
+#            - ../scenarios-hub/standalone/vm-storage-nfs-failover.yml
+#
+
+vm_storage_chaos:
+  action: nfs_failover                     # Kill and restart NFS service
+  storage_targets:
+    - host: <NFS_SERVER_HOST>              # IP or hostname of NFS server
+      path: /var/lib/containers            # NFS export path to disrupt
+  ssh_user: root                           # SSH username on NFS server
+  ssh_private_key: ~/.ssh/id_rsa           # Path to SSH private key
+  duration: 120                            # Seconds to keep NFS service down
+  io_workers: 4                            # Concurrent IO workers for stress
+  io_bytes: 1G                            # Data volume per IO worker
+  verify_vm_recovery: true                 # Verify VMs recover after NFS returns
+  recovery_timeout: 300                    # Seconds to wait for VM recovery


### PR DESCRIPTION
# Description

Add 14 example files for standalone chaos (no Kubernetes required):
- SSH node reboot/crash scenarios
- CPU/memory/IO hog standalone scenarios
- Network latency/partition scenarios
- Time skew, disk fill, file chaos scenarios
- VM storage NFS failover and migration disruption scenarios
- Standalone and VMware validation config files

## Related PRs
- krkn-chaos/krkn#1458: standalone execution mode

## Test plan
- [x] All 14 YAML files validated
- [x] Field names match krkn plugin implementations